### PR TITLE
Fix unit tests for "shell" func

### DIFF
--- a/adb.py
+++ b/adb.py
@@ -43,12 +43,8 @@ def shell(subcommand):
     example: "adb shell cat filename.txt"
 
     """
-    if subcommand is not None:
-        adb_full_cmd = [ ADB_COMMAND_PREFIX, ADB_COMMAND_SHELL, subcommand ]
-        return exec_command(adb_full_cmd)
-    else:
-        print("Please specify subcommand which will be executed in adb shell")
-        return 1
+    adb_full_cmd = [ ADB_COMMAND_PREFIX, ADB_COMMAND_SHELL, subcommand ]
+    return exec_command(adb_full_cmd)
 
 def exec_command(adb_full_cmd):
     """Executes adb command and handles result code.

--- a/test/adb_test.py
+++ b/test/adb_test.py
@@ -115,13 +115,9 @@ class TestShellCommand(unittest.TestCase):
         #search for time attribute which is for sure present in "-l" option
         self.assertRegexpMatches(result[1], '[0-2][0-9]:[0-5][0-9]')
 
-    def test_shell_n_misspelle(self):
+    def test_shell_n_misspelled(self):
         result = adb.shell('misspelled')
-        #todo:implement assert
-
-    def test_shell_n_wo_subcommand(self):
-        result = adb.shell()
-        #todo:implement assert
+        self.assertRegexpMatches(result[1], 'not found')
 
 class TestExecCommand(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
* Assertion for "test_shell_n_misspelled" has been added
* "test_shell_n_wo_subcommand" test has been removed since there is no sense to check missing function argument. It's already done by python. 

Change-Id: I3db3bddb941942572d9465c14ad3e19fb0356e54